### PR TITLE
fix: viewport js 

### DIFF
--- a/client/private/src/js/shared/fixViewport.js
+++ b/client/private/src/js/shared/fixViewport.js
@@ -1,9 +1,7 @@
-function fixViewport(){
+document.onload(()=>{
     let vh = window.innerHeight * 0.01;
     document.documentElement.style.setProperty('--vh', `${vh}px`);
 
     let scrollbarWidth = window.innerWidth - document.body.clientWidth;
     document.documentElement.style.setProperty("--scrollbar-width", `${scrollbarWidth}px`);
-}
-
-fixViewport();
+});


### PR DESCRIPTION
- se ejecutaba a veces porque el documento no alcanzaba a cargar antes de ejecutarlo.