### PR TITLE
fix: materia card img

### DIFF
--- a/client/private/src/html/alumno.html
+++ b/client/private/src/html/alumno.html
@@ -35,7 +35,9 @@
 
     <div class="materias-wrapper flex-c-c">
         <div class="materia-card">
-            <img class="materia-card-img" src="https://i.ytimg.com/vi/1pzaGvQS45k/maxresdefault.jpg" alt="Logo materia">
+            <div class="materia-card-img-wrapper">
+                <img class="materia-card-img" src="https://i.ytimg.com/vi/1pzaGvQS45k/maxresdefault.jpg" alt="Logo materia">
+            </div>
             <div class="materia-card-text-wrapper">
                 <h2 class="materia-card-title">Pegar puros headshots</h2>
                 <h2 class="materia-card-profesor">Cátedra: Camejo</h2>
@@ -44,7 +46,9 @@
         </div>
 
         <div class="materia-card materia-inscripto">
-            <img class="materia-card-img" src="https://skinsmonkey.com/blog/wp-content/uploads/sites/2/csgo-bomb-code-ingame.jpg" alt="Logo materia">
+            <div class="materia-card-img-wrapper">
+                <img class="materia-card-img" src="https://skinsmonkey.com/blog/wp-content/uploads/sites/2/csgo-bomb-code-ingame.jpg" alt="Logo materia">
+            </div>
             <div class="materia-card-text-wrapper">
                 <h2 class="materia-card-title">Plantar la bomba sin morir en el intento</h2>
                 <h2 class="materia-card-profesor">Cátedra: Nico Riedel 🐐</h2>
@@ -53,7 +57,9 @@
         </div>
 
         <div class="materia-card">
-            <img class="materia-card-img" src="https://i.imgflip.com/1ixrwd.jpg" alt="Logo materia">
+            <div class="materia-card-img-wrapper">
+                <img class="materia-card-img" src="https://i.imgflip.com/1ixrwd.jpg" alt="Logo materia">
+            </div>
             <div class="materia-card-text-wrapper">
                 <h2 class="materia-card-title">La Psicología del atacante</h2>
                 <h2 class="materia-card-profesor">Cátedra: Manu Bilbao</h2>

--- a/client/private/src/scss/shared/materia-card.scss
+++ b/client/private/src/scss/shared/materia-card.scss
@@ -51,7 +51,7 @@
 //PC only
 @media(min-width: 768px){
     .materia-card{
-        min-height: 25vh;
+        height: 25vh;
         width: 60vw;
         overflow: hidden;
 

--- a/client/private/src/scss/shared/materia-card.scss
+++ b/client/private/src/scss/shared/materia-card.scss
@@ -4,16 +4,23 @@
     border: 1.5px solid white;
     border-radius: 10px;
     display: flex;
-    align-items: center;
+    align-items: stretch;
     justify-content: center;
     flex-direction: row;
     background-color: rgba($color: #444, $alpha: 0.75);
+    overflow: hidden;
 
-    .materia-card-img{
-        object-fit: cover;
-        object-position: center;
+    .materia-card-img-wrapper{
+        position: relative;
+        
+        .materia-card-img{
+            width: 100%; height: 100%;
 
-        border-right: 1.5px solid white;
+            object-fit: cover;
+            object-position: center;
+
+            border-right: 1.5px solid white;
+        }
     }
 
     .materia-card-text-wrapper{
@@ -21,6 +28,7 @@
         flex-direction: column;
         justify-content: center;
         align-items: start;
+        width: 100%;
 
         .materia-card-title{
             font-family: Rubik;
@@ -51,17 +59,14 @@
 //PC only
 @media(min-width: 768px){
     .materia-card{
-        height: 25vh;
         width: 60vw;
-        overflow: hidden;
 
-        .materia-card-img{
-            width: 35%;
-            height: 100%;
+        .materia-card-img-wrapper{
+            width: 37.5vw;
         }
 
         .materia-card-text-wrapper{
-            padding-inline: 2vw;
+            padding: 2vw;
             gap: 1vh;
 
             .materia-card-profesor{


### PR DESCRIPTION
arreglo que en materia-card la imagen no se expandía correctamente cuando se agrandaba el container por el texto, ahora se puede expandir indefinidamente como era esperado.